### PR TITLE
update elastisticSearch version to stable

### DIFF
--- a/ansible/roles/ocp4-workload-debugging-workshop/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-debugging-workshop/defaults/main.yml
@@ -41,8 +41,8 @@ workshop_servicemesh:
   operatorhub_csv: servicemeshoperator.v2.1.0
 
 workshop_elasticsearch:
-  operatorhub_channel: stable-5.2
-  operatorhub_csv: elasticsearch-operator.5.2.3-31
+  operatorhub_channel: stable
+  operatorhub_csv: elasticsearch-operator.5.2.2-21
 
 workshop_jaeger:
   operatorhub_channel: stable


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
agnoticD deplyment of the workshop. Previously the deployer was stucked on the elasticsearch version. 
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

to correct :
TASK [ocp4-workload-debugging-workshop : Wait for Istio to start]
